### PR TITLE
OpanMP calls defined by preprocessor

### DIFF
--- a/Source_files/Algebra_tools.f90
+++ b/Source_files/Algebra_tools.f90
@@ -25,7 +25,10 @@
 MODULE Algebra_tools
 use Universal_constants
 
-USE OMP_LIB, only : OMP_GET_THREAD_NUM
+! For OpenMP external library
+#ifdef OMP_inside
+   USE OMP_LIB, only : OMP_GET_THREAD_NUM
+#endif
 
 implicit none
 PRIVATE
@@ -1100,7 +1103,9 @@ subroutine c8_diagonalize(M, Ev, Error_descript, print_Ei, check_M) ! double pre
    M = M_work ! save processed matrix back into the output matrix
    !!$OMP END WORKSHARE
 
-   print*, OMP_GET_THREAD_NUM(), 'Before check_M'
+#ifdef OMP_inside
+   !print*, OMP_GET_THREAD_NUM(), 'Before check_M'
+#endif
 
    if (present(check_M)) then
       if (check_M) then
@@ -1109,7 +1114,9 @@ subroutine c8_diagonalize(M, Ev, Error_descript, print_Ei, check_M) ! double pre
       endif
    endif
 
-   print*, OMP_GET_THREAD_NUM(), 'After check_M'
+#ifdef OMP_inside
+   !print*, OMP_GET_THREAD_NUM(), 'After check_M'
+#endif
 
    ! Clean up temporary arrays:
    deallocate(M_save, M_work)

--- a/Source_files/Optical_parameters.f90
+++ b/Source_files/Optical_parameters.f90
@@ -46,7 +46,9 @@ use Little_subroutines, only : deallocate_array, Find_in_array_monoton, d_Fermi_
 use MC_cross_sections, only : Mean_free_path, velosity_from_kinetic_energy
 use Nonadiabatic, only : get_Mij2, get_nonadiabatic_Pij
 
-USE OMP_LIB, only : OMP_GET_THREAD_NUM
+#ifdef OMP_inside
+   USE OMP_LIB, only : OMP_GET_THREAD_NUM
+#endif
 
 implicit none
 PRIVATE
@@ -240,8 +242,13 @@ subroutine get_Kubo_Greenwood_all_complex(numpar, matter, Scell, NSC, all_w, Err
 
       ! k-points:
       call k_point_choice(schem, ix, iy, iz, ixm, iym, izm, kx, ky, kz, numpar%k_grid) ! module "TB"
+
+#ifdef OMP_inside
       if (numpar%verbose) write(*,'(a,i4,a,i6,i3,i3,i3,f9.4,f9.4,f9.4,a)') 'Thread #', OMP_GET_THREAD_NUM(), &
                                      ' point #', Ngp, ix, iy, iz, kx, ky, kz, ' Kubo-Greenwood'
+#else
+      if (numpar%verbose) write(*,'(a,i7,i3,i3,i3,f9.4,f9.4,f9.4,a)') ' point #', Ngp, ix, iy, iz, kx, ky, kz, ' Kubo-Greenwood'
+#endif
 
       ! Get the effective momentum and kinetic-energy-related operators:
       ASSOCIATE (ARRAY => Scell(NSC)%TB_Hamil(:,:))
@@ -1077,8 +1084,14 @@ subroutine get_Graf_Vogl_all_complex(numpar, Scell, NSC, all_w, Err)  ! From Ref
 
       ! k-points:
       call k_point_choice(schem, ix, iy, iz, ixm, iym, izm, kx, ky, kz, numpar%k_grid) ! module "TB"
+
+#ifdef OMP_inside
       if (numpar%verbose) write(*,'(a,i4,a,i7,i3,i3,i3,f9.4,f9.4,f9.4,a)') 'Thread #', OMP_GET_THREAD_NUM(), &
                                      ' point #', Ngp, ix, iy, iz, kx, ky, kz, ' Graf-Vogl'
+#else
+      if (numpar%verbose) write(*,'(a,i7,i3,i3,i3,f9.4,f9.4,f9.4,a)') ' point #', Ngp, ix, iy, iz, kx, ky, kz, ' Graf-Vogl'
+#endif
+
 
       ! Get the effective momentum and kinetic-energy-related operators:
       ASSOCIATE (ARRAY => Scell(NSC)%TB_Hamil(:,:))

--- a/Source_files/TB_NRL.f90
+++ b/Source_files/TB_NRL.f90
@@ -34,7 +34,9 @@ use Algebra_tools, only : mkl_matrix_mult, sym_diagonalize, Reciproc, check_herm
 use Atomic_tools, only : get_near_neighbours, get_number_of_image_cells, distance_to_given_cell, shortest_distance, Reciproc_rel_to_abs
 use Electron_tools, only : find_band_gap
 
-USE OMP_LIB, only : OMP_GET_THREAD_NUM
+#ifdef OMP_inside
+   USE OMP_LIB, only : OMP_GET_THREAD_NUM
+#endif
 
 implicit none
 PRIVATE
@@ -1139,7 +1141,11 @@ subroutine Loewdin_Orthogonalization_c8(Nsiz, Sij, Hij, Err) ! below
     if (allocated(s_mat)) deallocate(s_mat)
     if (allocated(Ev)) deallocate(Ev)
 
-    print*, OMP_GET_THREAD_NUM(), 'Loewdin_Orthogonalization_c8 done'
+#ifdef OMP_inside
+      print*, OMP_GET_THREAD_NUM(), 'Loewdin_Orthogonalization_c8 done'
+#else
+      print*, 'Loewdin_Orthogonalization_c8 done'
+#endif
 end subroutine Loewdin_Orthogonalization_c8
 
 

--- a/Source_files/TB_complex.f90
+++ b/Source_files/TB_complex.f90
@@ -31,7 +31,9 @@ use Optical_parameters, only : allocate_Eps_hw, get_Onsager_coeffs, get_Kubo_Gre
 use Electron_tools, only : get_DOS_sort
 use Little_subroutines, only : Find_in_array_monoton, linear_interpolation
 
-USE OMP_LIB, only : OMP_GET_THREAD_NUM
+#ifdef OMP_inside
+   USE OMP_LIB, only : OMP_GET_THREAD_NUM
+#endif
 
 implicit none
 PRIVATE
@@ -120,8 +122,13 @@ subroutine use_complex_Hamiltonian(numpar, matter, Scell, NSC, Err)  ! From Ref.
       !-------------------------------
       ! k-points:
       call k_point_choice(schem, ix, iy, iz, ixm, iym, izm, kx, ky, kz, numpar%k_grid) ! module "TB"
+
+#ifdef OMP_inside
       if (numpar%verbose) write(*,'(a,i4,a,i6,i3,i3,i3,f9.4,f9.4,f9.4,a)') 'Thread #', OMP_GET_THREAD_NUM(), &
                                      ' point #', Ngp, ix, iy, iz, kx, ky, kz, ' k-points'
+#else
+      if (numpar%verbose) write(*,'(a,i7,i3,i3,i3,f9.4,f9.4,f9.4,a)') ' point #', Ngp, ix, iy, iz, kx, ky, kz, ' k-points'
+#endif
 
       !-------------------------------
       ! Get the parameters of the complex Hamiltonian:


### PR DESCRIPTION
- if compiled without OMP, no calls to OpenMP-specific subroutines are used; should make XTANT compilable without OMP